### PR TITLE
fix(): Remove unused `chain` parameter from `/metrics`

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -123,10 +123,8 @@ export class BadgerAPI {
     });
   }
 
-  async loadProtocolMetrics(network?: Network): Promise<ProtocolMetrics> {
-    return this.get('metrics', {
-      chain: network ?? this.network,
-    });
+  async loadProtocolMetrics(): Promise<ProtocolMetrics> {
+    return this.get('metrics');
   }
 
   async loadProtocolSummary(


### PR DESCRIPTION
Does look like this is used: https://github.com/Badger-Finance/badger-api/blob/main/src/metrics/metrics.controller.ts#L18-L20