### PR TITLE
fix: disable commit hooks for ci

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install commitlint --edit $1
+if [[ $CI != true ]]; then
+  npx --no-install commitlint --edit $1
+fi;

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint
-yarn pretty-quick --staged
+if [[ $CI != true ]]; then
+  yarn lint
+  yarn pretty-quick --staged
+fi;


### PR DESCRIPTION
Looks like commit-lint hook https://github.com/Badger-Finance/badger-sdk/runs/5415897044?check_suite_focus=true#step:8:103 Cant get along with release bot msgs.

So i`ve disabled pre-commit hooks for CI jobs, with default env var
https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables

Anyways they are pointless, coz we have same checks on CI