### PR TITLE
Chore: Get vault strategy should return strat address

### DIFF
--- a/src/vaults/vaults.service.spec.ts
+++ b/src/vaults/vaults.service.spec.ts
@@ -5,6 +5,7 @@ import { Network } from '../config';
 
 describe('vaults.service', () => {
   let sdk: BadgerSDK;
+  let service: VaultsService;
 
   beforeAll(async () => {
     sdk = new BadgerSDK({
@@ -12,11 +13,11 @@ describe('vaults.service', () => {
       // TODO: Find out how to replace RPC calls with proper mocks
       provider: 'https://rpc.ftm.tools/',
     });
+    service = new VaultsService(sdk);
   });
 
   describe('getVaultStrategy', () => {
     it('should return v1.5 strategy', async function () {
-      const service = new VaultsService(sdk);
       // BVEOXD vault that is v1.5 vault
       const address = '0x96d4dBdc91Bef716eb407e415c9987a9fAfb8906';
       const version = VaultVersion.v1_5;

--- a/src/vaults/vaults.service.spec.ts
+++ b/src/vaults/vaults.service.spec.ts
@@ -9,6 +9,7 @@ describe('vaults.service', () => {
   beforeAll(async () => {
     sdk = new BadgerSDK({
       network: Network.Ethereum,
+      // TODO: Find out how to replace RPC calls with proper mocks
       provider: 'https://rpc.ftm.tools/',
     });
   });

--- a/src/vaults/vaults.service.spec.ts
+++ b/src/vaults/vaults.service.spec.ts
@@ -1,0 +1,34 @@
+import { VaultsService } from './vaults.service';
+import { BadgerSDK } from '../sdk';
+import { VaultVersion } from './enums';
+import { Network } from '../config';
+
+describe('vaults.service', () => {
+  let sdk: BadgerSDK;
+
+  beforeAll(async () => {
+    sdk = new BadgerSDK({
+      network: Network.Ethereum,
+      provider: 'https://rpc.ftm.tools/',
+    });
+  });
+
+  describe('getVaultStrategy', () => {
+    it('should return v1.5 strategy', async function () {
+      const service = new VaultsService(sdk);
+      // BVEOXD vault that is v1.5 vault
+      const address = '0x96d4dBdc91Bef716eb407e415c9987a9fAfb8906';
+      const version = VaultVersion.v1_5;
+      const strategy = await service.getVaultStrategy({ address, version });
+      expect(strategy).toEqual('0x0c7E0807011A218d0F1A156D3965875ff233933E');
+    });
+    it('should return v1 strategy', async function () {
+      const service = new VaultsService(sdk);
+      // BSMM_WBTC_RENBTC vault that is v1 vault
+      const address = '0xb6d63a4e5ca740e96c26adabcac73be78ee39dc5';
+      const version = VaultVersion.v1;
+      const strategy = await service.getVaultStrategy({ address, version });
+      expect(strategy).toEqual('0x711555f2B421DA9A86a18Dc163d04699310fE297');
+    });
+  });
+});

--- a/src/vaults/vaults.service.spec.ts
+++ b/src/vaults/vaults.service.spec.ts
@@ -30,5 +30,14 @@ describe('vaults.service', () => {
       const strategy = await service.getVaultStrategy({ address, version });
       expect(strategy).toEqual('0x711555f2B421DA9A86a18Dc163d04699310fE297');
     });
+    it('incompatible vault should throw', async function () {
+      const service = new VaultsService(sdk);
+      const address = '0x96d4dBdc91Bef716eb407e415c9987a9fAfb8906';
+      // Set incompatible vault version
+      const version = VaultVersion.v1;
+      await expect(
+        async () => await service.getVaultStrategy({ address, version }),
+      ).rejects.toThrow(Error);
+    });
   });
 });

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -152,7 +152,7 @@ export class VaultsService extends Service {
       await vault.controller(),
       this.sdk.provider,
     );
-    return await controller.strategies(await vault.token());
+    return controller.strategies(await vault.token());
   }
 
   async getPendingYield(

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -23,7 +23,6 @@ import {
   LoadVaultOptions,
   VaultHarvestData,
 } from './interfaces';
-import { Strategy } from '../contracts/Strategy';
 import {
   loadVaultPerformanceEvents,
   loadVaultV15PerformanceEvents,
@@ -132,26 +131,28 @@ export class VaultsService extends Service {
       const vault = VaultV15__factory.connect(address, this.sdk.provider);
       return loadVaultV15PerformanceEvents(vault, options);
     }
-    const strategy = await this.getVaultStrategy({ address, version });
+    const strategyAddress = await this.getVaultStrategy({ address, version });
+    const strategy = Strategy__factory.connect(
+      strategyAddress,
+      this.sdk.provider,
+    );
     return loadVaultPerformanceEvents(strategy, options);
   }
 
   async getVaultStrategy({
     address,
     version = VaultVersion.v1,
-  }: GetVaultStrategyOptions): Promise<Strategy> {
+  }: GetVaultStrategyOptions): Promise<string> {
     if (version === VaultVersion.v1_5) {
       const vault = VaultV15__factory.connect(address, this.sdk.provider);
-      const strategyAddress = await vault.strategy();
-      return Strategy__factory.connect(strategyAddress, this.sdk.provider);
+      return await vault.strategy();
     }
     const vault = Vault__factory.connect(address, this.sdk.provider);
     const controller = Controller__factory.connect(
       await vault.controller(),
       this.sdk.provider,
     );
-    const strategyAddress = await controller.strategies(await vault.token());
-    return Strategy__factory.connect(strategyAddress, this.sdk.provider);
+    return await controller.strategies(await vault.token());
   }
 
   async getPendingYield(


### PR DESCRIPTION
Update `getVaultStrategy` to return strategy address instead of relevant strategy contract instance

Fixes #104 