### PR TITLE
fix: update account interface extension fields

### DIFF
--- a/src/api/interfaces/account.interface.ts
+++ b/src/api/interfaces/account.interface.ts
@@ -3,17 +3,8 @@ import { VaultData } from './vault-data.interface';
 
 export interface Account extends UserBoostData {
   address: string;
-  boost: number;
-  boostRank: number;
-  bveCvxBalance: number;
   claimableBalances: Record<string, string>;
   data: Record<string, VaultData>;
-  diggBalance: number;
   earnedValue: number;
-  multipliers: Record<string, number>;
-  nativeBalance: number;
-  nftBalance: number;
-  nonNativeBalance: number;
-  stakeRatio: number;
   value: number;
 }

--- a/src/api/interfaces/user-boost-data.interface.ts
+++ b/src/api/interfaces/user-boost-data.interface.ts
@@ -1,6 +1,6 @@
 export interface UserBoostData {
   address: string;
-  rank: number;
+  boostRank: number;
   boost: number;
   stakeRatio: number;
   nftBalance: number;


### PR DESCRIPTION
# Summary

Properly inherit fields from `UserBoostData` rename to appropriate fields for API expectations ignoring internal changes as it does not impact the end user.