### PR TITLE
chore: hardcode digg data since no rebasing

### DIFF
--- a/src/digg/digg.service.ts
+++ b/src/digg/digg.service.ts
@@ -31,7 +31,7 @@ export class DiggService extends Service {
     return this._digg;
   }
 
-  async convert(shares: BigNumber): Promise<number> {
+  convert(shares: BigNumber): number {
     const fragments = shares.div(DIGG_SHARES_PER_FRAGMENT);
     return formatBalance(fragments, DIGG_DECIMALS);
   }

--- a/src/digg/digg.service.ts
+++ b/src/digg/digg.service.ts
@@ -11,6 +11,8 @@ import { formatBalance } from '../tokens/tokens.utils';
 export const DIGG_ADDRESS = ethers.utils.getAddress(
   '0x798D1bE841a82a273720CE31c822C61a67a601C3',
 );
+export const DIGG_SHARES_PER_FRAGMENT = BigNumber.from("222256308823765331027878635805365830922307440079959220679625904457");
+export const DIGG_DECIMALS = BigNumber.from("9");
 
 export class DiggService extends Service {
   private _digg?: Digg;
@@ -30,10 +32,7 @@ export class DiggService extends Service {
   }
 
   async convert(shares: BigNumber): Promise<number> {
-    const [fragments, token] = await Promise.all([
-      this.digg.sharesToFragments(shares),
-      this.sdk.tokens.loadToken(this.digg.address),
-    ]);
-    return formatBalance(fragments, token.decimals);
+    const fragments = shares.div(DIGG_SHARES_PER_FRAGMENT);
+    return formatBalance(fragments, DIGG_DECIMALS);
   }
 }


### PR DESCRIPTION
DIGG no longer rebases.  We hardcode in the data from the smart contract to make it accessible throughout applications without needing an SDK instance, as well as update the convert function to no longer make unnecessary web3 calls