### PR TITLE
chore: coerce to BigNumber

### DIFF
--- a/src/digg/digg.service.ts
+++ b/src/digg/digg.service.ts
@@ -32,7 +32,7 @@ export class DiggService extends Service {
   }
 
   convert(shares: BigNumber): number {
-    const fragments = shares.div(DIGG_SHARES_PER_FRAGMENT);
+    const fragments = BigNumber.from(shares).div(DIGG_SHARES_PER_FRAGMENT);
     return formatBalance(fragments, DIGG_DECIMALS);
   }
 }


### PR DESCRIPTION
Mocks throwing errors  - coercing to BigNumber to prevent issues