### PR TITLE
fix: check if user rejected txs

### DIFF
--- a/src/ibbtc/ibbtc.service.ts
+++ b/src/ibbtc/ibbtc.service.ts
@@ -188,6 +188,10 @@ export class ibBTCService extends Service {
       }
 
       const tokenInfo = await this.sdk.tokens.loadToken(token);
+
+      if (onTransferPrompt) {
+        onTransferPrompt({ token: tokenInfo.name, amount });
+      }
       let mintTx;
       if (zapType === IbBtcZapType.Peak) {
         mintTx = await this.vaultPeak.mint(0, amount, [], { ...overrides });
@@ -198,9 +202,6 @@ export class ibBTCService extends Service {
       } else {
         const { poolId, idx } = await this.tokenZap.calcMint(token, amount);
         mintTx = await this.tokenZap.mint(token, amount, poolId, idx, amount);
-      }
-      if (onTransferPrompt) {
-        onTransferPrompt({ token: tokenInfo.name, amount });
       }
       result = TransactionStatus.Pending;
       if (onTransferSigned) {
@@ -260,12 +261,13 @@ export class ibBTCService extends Service {
       }
 
       const tokenInfo = await this.sdk.tokens.loadToken(token);
-      const redeemTx = await this.vaultPeak.redeem(0, amount, {
-        ...overrides,
-      });
+
       if (onTransferPrompt) {
         onTransferPrompt({ token: tokenInfo.name, amount });
       }
+      const redeemTx = await this.vaultPeak.redeem(0, amount, {
+        ...overrides,
+      });
       result = TransactionStatus.Pending;
       if (onTransferSigned) {
         onTransferSigned({

--- a/src/utils/is-tx-rejection-error.test.ts
+++ b/src/utils/is-tx-rejection-error.test.ts
@@ -1,0 +1,12 @@
+import { isUserTxRejectionError } from './is-tx-rejection-error';
+
+describe('isTxRejectionError', () => {
+  it('should return true if error is a TxRejectionError', () => {
+    expect(isUserTxRejectionError({ code: 4001 })).toBe(true);
+  });
+
+  it('should return false if error is not a TxRejectionError', () => {
+    const error = new Error('test');
+    expect(isUserTxRejectionError(error)).toBe(false);
+  });
+});

--- a/src/utils/is-tx-rejection-error.ts
+++ b/src/utils/is-tx-rejection-error.ts
@@ -1,0 +1,9 @@
+export const USER_REJECTED_TX_CODE = 4001;
+
+type WalletError = {
+  code: number;
+};
+
+export function isUserTxRejectionError(error: unknown): boolean {
+  return (error as WalletError).code === USER_REJECTED_TX_CODE;
+}

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -331,7 +331,7 @@ export class VaultsService extends Service {
       return TransactionStatus.Failure;
     }
 
-    let result: TransactionStatus;
+    let result = TransactionStatus.UserConfirmation;
 
     try {
       if (onTransferPrompt) {
@@ -341,6 +341,7 @@ export class VaultsService extends Service {
       if (onTransferSigned) {
         onTransferSigned({ token, amount, transaction: withdrawTx });
       }
+      result = TransactionStatus.Pending;
       const receipt = await withdrawTx.wait();
       if (onTransferSuccess) {
         onTransferSuccess({ token, amount, receipt });

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -272,14 +272,14 @@ export class VaultsService extends Service {
         proof = await this.api.loadProof(this.address);
       } catch {} // ignore no proofs
       const tokenName = await vaultContract.name();
+      if (onTransferPrompt) {
+        onTransferPrompt({ token, amount });
+      }
       const depositTx = await vaultContract['deposit(uint256,bytes32[])'](
         amount,
         proof,
         { ...overrides },
       );
-      if (onTransferPrompt) {
-        onTransferPrompt({ token, amount });
-      }
       result = TransactionStatus.Pending;
       if (onTransferSigned) {
         onTransferSigned({ token: tokenName, amount, transaction: depositTx });
@@ -334,10 +334,10 @@ export class VaultsService extends Service {
     let result: TransactionStatus;
 
     try {
-      const withdrawTx = await vaultContract.withdraw(amount, { ...overrides });
       if (onTransferPrompt) {
         onTransferPrompt({ token, amount });
       }
+      const withdrawTx = await vaultContract.withdraw(amount, { ...overrides });
       if (onTransferSigned) {
         onTransferSigned({ token, amount, transaction: withdrawTx });
       }


### PR DESCRIPTION
closes #229

I found out that with the following code:

```js
if (onTransferPrompt) {
   onTransferPrompt(params);
 }

const tx = await contract.call()
```

the prompt is displayed even if the contract call fails. We can fix this by simply moving the prompt below the contract call.
