### PR TITLE
fix: check for registry before attempting to load vaults

### DIFF
--- a/src/registry/registry.service.ts
+++ b/src/registry/registry.service.ts
@@ -73,6 +73,13 @@ export class RegistryService extends Service {
   }
 
   async getProductionVaults(): Promise<VaultRegistryEntry[]> {
+    if (!this.hasRegistry()) {
+      this.debug(
+        `${this.config.network} does not have a registry. No vaults are discoverable.`,
+      );
+      return [];
+    }
+
     const prdVaults = await this.registry.getProductionVaults();
 
     return prdVaults

--- a/src/rewards/rewards.service.ts
+++ b/src/rewards/rewards.service.ts
@@ -157,10 +157,15 @@ export class RewardsService extends Service {
     try {
       await this.sdk.registry.ready();
 
+      if (!this.sdk.registry.hasRegistry()) {
+        return;
+      }
+
       const [badgerTreeAddress, rewardsLoggerAddress] = await Promise.all([
         this.sdk.registry.get(RegistryKey.BadgerTree),
         this.sdk.registry.get(RegistryKey.RewardsLogger),
       ]);
+
       if (badgerTreeAddress) {
         this._badgerTree = BadgerTree__factory.connect(
           badgerTreeAddress,

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -43,11 +43,6 @@ export class VaultsService extends Service {
   private vaults: Record<string, RegistryVault> = {};
 
   async loadVaults(): Promise<RegistryVault[]> {
-    if (!this.sdk.registry.hasRegistry()) {
-      this.debug(`${this.config.network} does not have a registry. No vaults are discoverable.`);
-      return [];
-    }
-
     const registry = await this.sdk.registry.getProductionVaults();
     const serializedCachedVaults = JSON.stringify(
       Object.keys(this.vaults).sort(),

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -43,6 +43,11 @@ export class VaultsService extends Service {
   private vaults: Record<string, RegistryVault> = {};
 
   async loadVaults(): Promise<RegistryVault[]> {
+    if (!this.sdk.registry.hasRegistry()) {
+      this.debug(`${this.config.network} does not have a registry. No vaults are discoverable.`);
+      return [];
+    }
+
     const registry = await this.sdk.registry.getProductionVaults();
     const serializedCachedVaults = JSON.stringify(
       Object.keys(this.vaults).sort(),


### PR DESCRIPTION
# Summary

- fix issue where networks without registries attempted to use the registry to load data causing issues

```
Failed to get badgerTree [
  [
    Error: Registry is not defined for binance-smart-chain
        at RegistryService.get registry [as registry] (/home/jintao/Documents/badger/badger-api/node_modules/@badger-dao/sdk/lib/registry/registry.service.js:24:19)
        at RegistryService.get (/home/jintao/Documents/badger/badger-api/node_modules/@badger-dao/sdk/lib/registry/registry.service.js:34:48)
        at RewardsService.init (/home/jintao/Documents/badger/badger-api/node_modules/@badger-dao/sdk/lib/rewards/rewards.service.js:108:35)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async Promise.all (index 2)
        at async BinanceSmartChain.getSdk (/home/jintao/Documents/badger/badger-api/.build/src/chains/config/chain.config.js:60:9)
        at async captureVaultData (/home/jintao/Documents/badger/badger-api/.build/src/indexers/vault-definition-indexer.js:11:21)
        at async InProcessRunner.run (/home/jintao/Documents/badger/badger-api/node_modules/serverless-offline/dist/lambda/handler-runner/in-process-runner/InProcessRunner.js:213:28)
        at async process.<anonymous> (/home/jintao/Documents/badger/badger-api/node_modules/serverless-offline/dist/lambda/handler-runner/child-process-runner/childProcessHelper.js:37:18)
  ]
]
Failed to get rewardsLogger [
  [
    Error: Registry is not defined for binance-smart-chain
        at RegistryService.get registry [as registry] (/home/jintao/Documents/badger/badger-api/node_modules/@badger-dao/sdk/lib/registry/registry.service.js:24:19)
        at RegistryService.get (/home/jintao/Documents/badger/badger-api/node_modules/@badger-dao/sdk/lib/registry/registry.service.js:34:48)
        at RewardsService.init (/home/jintao/Documents/badger/badger-api/node_modules/@badger-dao/sdk/lib/rewards/rewards.service.js:109:35)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async Promise.all (index 2)
        at async BinanceSmartChain.getSdk (/home/jintao/Documents/badger/badger-api/.build/src/chains/config/chain.config.js:60:9)
        at async captureVaultData (/home/jintao/Documents/badger/badger-api/.build/src/indexers/vault-definition-indexer.js:11:21)
        at async InProcessRunner.run (/home/jintao/Documents/badger/badger-api/node_modules/serverless-offline/dist/lambda/handler-runner/in-process-runner/InProcessRunner.js:213:28)
        at async process.<anonymous> (/home/jintao/Documents/badger/badger-api/node_modules/serverless-offline/dist/lambda/handler-runner/child-process-runner/childProcessHelper.js:37:18)
  ]
]
Registry is not defined for binance-smart-chain
```