### PR TITLE
fix: utilize read only provider

### DIFF
--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -165,15 +165,15 @@ export class VaultsService extends Service {
     }
 
     if (version === VaultVersion.v1_5) {
-      const vault = VaultV15__factory.connect(address, this.connector);
+      const vault = VaultV15__factory.connect(address, this.provider);
       return loadVaultV15PerformanceEvents(vault, <RangeOptions>options);
     }
-    const vault = Vault__factory.connect(address, this.connector);
+    const vault = Vault__factory.connect(address, this.provider);
     const [strategyAddress, depositToken] = await Promise.all([
       this.getVaultStrategy({ address, version }),
       vault.token(),
     ]);
-    const strategy = Strategy__factory.connect(strategyAddress, this.connector);
+    const strategy = Strategy__factory.connect(strategyAddress, this.provider);
     return loadVaultPerformanceEvents(
       depositToken,
       strategy,
@@ -186,13 +186,13 @@ export class VaultsService extends Service {
     version = VaultVersion.v1,
   }: GetVaultStrategyOptions): Promise<string> {
     if (version === VaultVersion.v1_5) {
-      const vault = VaultV15__factory.connect(address, this.connector);
+      const vault = VaultV15__factory.connect(address, this.provider);
       return vault.strategy();
     }
-    const vault = Vault__factory.connect(address, this.connector);
+    const vault = Vault__factory.connect(address, this.provider);
     const controller = Controller__factory.connect(
       await vault.controller(),
-      this.connector,
+      this.provider,
     );
     return controller.strategies(await vault.token());
   }
@@ -395,7 +395,7 @@ export class VaultsService extends Service {
 
     const vault = Vault__factory.connect(
       ethers.utils.getAddress(address),
-      this.connector,
+      this.provider,
     );
 
     const [
@@ -446,7 +446,7 @@ export class VaultsService extends Service {
     if (isYearnWbtc) {
       const byvWbtc = Byvwbtc__factory.connect(
         ethers.utils.getAddress(this.wbtcYearnVault),
-        this.connector,
+        this.provider,
       );
 
       return [
@@ -465,14 +465,14 @@ export class VaultsService extends Service {
     harvest: boolean,
   ): Promise<{ lastHarvestedAt: number; tokenRewards: TokenBalance[] }> {
     const checksumAddress = ethers.utils.getAddress(address);
-    const vault = VaultV15__factory.connect(checksumAddress, this.connector);
+    const vault = VaultV15__factory.connect(checksumAddress, this.provider);
     const [lastHarvestedAt, strategyAddress] = await Promise.all([
       vault.lastHarvestedAt(),
       vault.strategy(),
     ]);
     const strategy = StrategyV15__factory.connect(
       strategyAddress,
-      this.connector,
+      this.provider,
     );
     let pendingRewards;
     if (harvest) {


### PR DESCRIPTION
# Summary

- do not require a signer when using the vault read functions